### PR TITLE
[FEAT/FIX] Email validation

### DIFF
--- a/src/modules/user/dto/create-user.dto.ts
+++ b/src/modules/user/dto/create-user.dto.ts
@@ -50,6 +50,12 @@ export class CreateUserDto {
   @IsString()
   @IsEmail()
   @MaxLength(250)
+  @Matches(
+    /[a-z0-9!#$%&’*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&’*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?/,
+    {
+      message: 'must be a valid email',
+    },
+  )
   email: string;
 
   @IsOptional()

--- a/src/modules/user/dto/update-user.dto.ts
+++ b/src/modules/user/dto/update-user.dto.ts
@@ -53,6 +53,12 @@ export class UpdateUserDto extends PartialType(CreateUserDto) {
   @IsString()
   @IsEmail()
   @MaxLength(250)
+  @Matches(
+    /[a-z0-9!#$%&’*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&’*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?/,
+    {
+      message: 'must be a valid email',
+    },
+  )
   email?: string;
 
   @IsOptional()


### PR DESCRIPTION
Validate email when creating or updating user.

Examples of invalid emails:
- user@example (missing the domain, such as .com)
- user.example.com (the domain does not follow the correct structure)
- user@.com (the domain does not have a valid part before the dot)
- user@-example.com (the domain starts with a hyphen)
- user@example..com (consecutive dots in the domain)