### PR TITLE
[FIX] Delete user data from all tables

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -18,7 +18,7 @@ async function bootstrap() {
   app.use(helmet.hidePoweredBy());
   app.use(helmet.contentSecurityPolicy());
 
-  app.use('/v2/api-doc', swaggerUi.serve, swaggerUi.setup(SwaggerDoc));
+  app.use('/v3/api-doc', swaggerUi.serve, swaggerUi.setup(SwaggerDoc));
 
   app.useGlobalPipes(
     new ValidationPipe({

--- a/src/modules/user/test/user.repository.spec.ts
+++ b/src/modules/user/test/user.repository.spec.ts
@@ -384,11 +384,29 @@ describe('User Repository', () => {
     });
 
     it('should delete users successfully', async () => {
-      jest.spyOn(prismaService.user, 'delete').mockResolvedValueOnce(null);
+      jest
+        .spyOn(prismaService, '$transaction')
+        .mockImplementation(async (callback) => {
+          await callback(prismaService);
+        });
+
+      jest.spyOn(prismaService.user, 'delete').mockResolvedValueOnce(MockUser);
+      jest
+        .spyOn(prismaService.userPersonalInfo, 'delete')
+        .mockResolvedValueOnce(null);
+      jest
+        .spyOn(prismaService.userContactInfo, 'delete')
+        .mockResolvedValueOnce(null);
+      jest
+        .spyOn(prismaService.userSecurityInfo, 'delete')
+        .mockResolvedValueOnce(null);
 
       await userRepository.deleteUser(MockUser.id);
 
       expect(prismaService.user.delete).toHaveBeenCalledTimes(1);
+      expect(prismaService.userPersonalInfo.delete).toHaveBeenCalledTimes(1);
+      expect(prismaService.userContactInfo.delete).toHaveBeenCalledTimes(1);
+      expect(prismaService.userSecurityInfo.delete).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/modules/user/test/user.repository.spec.ts
+++ b/src/modules/user/test/user.repository.spec.ts
@@ -408,6 +408,32 @@ describe('User Repository', () => {
       expect(prismaService.userContactInfo.delete).toHaveBeenCalledTimes(1);
       expect(prismaService.userSecurityInfo.delete).toHaveBeenCalledTimes(1);
     });
+
+    it('should throw an error if user not deleted', async () => {
+      jest
+        .spyOn(prismaService, '$transaction')
+        .mockImplementation(async (callback) => {
+          await callback(prismaService);
+        });
+
+      jest
+        .spyOn(prismaService.user, 'delete')
+        .mockRejectedValueOnce(
+          new AppError(
+            'user-repository.deleteUser',
+            500,
+            'failed to delete user',
+          ),
+        );
+
+      try {
+        await userRepository.deleteUser(MockUser.id);
+      } catch (error) {
+        expect(error).toBeInstanceOf(AppError);
+        expect(error.code).toBe(500);
+        expect(error.message).toBe('failed to delete user');
+      }
+    });
   });
 
   describe('reactivate user account', () => {


### PR DESCRIPTION
Issue: user data was only being deleted from `User` table.

Solution: 
- Tried to add `onDelete: Cascade` in prisma.schema relation tables but didn't work.
- Create transaction to delete data async in repository function.